### PR TITLE
Add downloadability of files

### DIFF
--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -20,6 +20,7 @@ package org.apache.cordova.inappbrowser;
 
 import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
+import android.content.ActivityNotFoundException;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -20,8 +20,6 @@ package org.apache.cordova.inappbrowser;
 
 import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
-import android.content.ActivityNotFoundException;
-import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
@@ -1196,15 +1194,8 @@ public class InAppBrowser extends CordovaPlugin {
 
             if (url.matches(".*\\.(pdf|rtf|doc|docx|xls|xlsx|ppt|pptx|zip|rar|mp3|mp4|mpg|mpeg|avi|wmv|mov|apk|odt|ods|txt|csv)(\\?.*)?$")) {
                 Intent intent = new Intent(Intent.ACTION_VIEW);
-                intent.setDataAndType(Uri.parse(url), "*/*");
-                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                try {
-                    cordova.getActivity().startActivity(intent);
-                    LOG.d(LOG_TAG, "shouldOverrideUrlLoading sending intent!");
-                } catch (ActivityNotFoundException e) {
-                    LOG.e(LOG_TAG, "No application found to open " + url, e);
-                }
-
+                intent.setDataAndType(Uri.parse(url));
+                cordova.getActivity().startActivity(intent);
                 return true;
             }
 

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -1190,6 +1190,24 @@ public class InAppBrowser extends CordovaPlugin {
         @TargetApi(Build.VERSION_CODES.N)
         @Override
         public boolean shouldOverrideUrlLoading(WebView webView, WebResourceRequest request) {
+
+            String url = request.getUrl().toString();
+
+            LOG.d(LOG_TAG, "shouldOverrideUrlLoading entered! " + url);
+            if (url.matches(".*\\.(pdf|doc|docx|xls|xlsx|ppt|pptx|zip|rar|mp3|mp4|avi|mov|apk|odt|ods)(\\?.*)?$")) {
+                Intent intent = new Intent(Intent.ACTION_VIEW);
+                intent.setDataAndType(Uri.parse(url), "*/*");
+                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                try {
+                    cordova.getActivity().startActivity(intent);
+                    LOG.d(LOG_TAG, "shouldOverrideUrlLoading sending intent!");
+                } catch (ActivityNotFoundException e) {
+                    LOG.e(LOG_TAG, "No application found to open " + url, e);
+                }
+
+                return true;
+            }
+
             return shouldOverrideUrlLoading(request.getUrl().toString(), request.getMethod());
         }
 

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -1194,7 +1194,7 @@ public class InAppBrowser extends CordovaPlugin {
             String url = request.getUrl().toString();
 
             LOG.d(LOG_TAG, "shouldOverrideUrlLoading entered! " + url);
-            if (url.matches(".*\\.(pdf|doc|docx|xls|xlsx|ppt|pptx|zip|rar|mp3|mp4|avi|mov|apk|odt|ods)(\\?.*)?$")) {
+            if (url.matches(".*\\.(pdf|rtf|doc|docx|xls|xlsx|ppt|pptx|zip|rar|mp3|mp4|mpg|mpeg|avi|wmv|mov|apk|odt|ods|txt|csv)(\\?.*)?$")) {
                 Intent intent = new Intent(Intent.ACTION_VIEW);
                 intent.setDataAndType(Uri.parse(url), "*/*");
                 intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -129,6 +129,7 @@ public class InAppBrowser extends CordovaPlugin {
     private boolean clearAllCache = false;
     private boolean clearSessionCache = false;
     private boolean hadwareBackButton = true;
+    private boolean hardwareBackDisabled = false;
     private boolean mediaPlaybackRequiresUserGesture = false;
     private boolean shouldPauseInAppBrowser = false;
     private boolean useWideViewPort = true;
@@ -580,6 +581,14 @@ public class InAppBrowser extends CordovaPlugin {
     }
 
     /**
+     * Has the user set the hardware back button to be ignored entirely
+     * @return boolean
+     */
+    public boolean hardwareBackDisabled() {
+        return hardwareBackDisabled;
+    }
+
+    /**
      * Checks to see if it is possible to go forward one page in history, then does so.
      */
     private void goForward() {
@@ -654,8 +663,10 @@ public class InAppBrowser extends CordovaPlugin {
             String hardwareBack = features.get(HARDWARE_BACK_BUTTON);
             if (hardwareBack != null) {
                 hadwareBackButton = hardwareBack.equals("yes") ? true : false;
+                hardwareBackDisabled = hardwareBack.equals("disabled") ? true : false;
             } else {
                 hadwareBackButton = DEFAULT_HARDWARE_BACK;
+                hardwareBackDisabled = false;
             }
             String mediaPlayback = features.get(MEDIA_PLAYBACK_REQUIRES_USER_ACTION);
             if (mediaPlayback != null) {

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -1193,7 +1193,6 @@ public class InAppBrowser extends CordovaPlugin {
 
             String url = request.getUrl().toString();
 
-            LOG.d(LOG_TAG, "shouldOverrideUrlLoading entered! " + url);
             if (url.matches(".*\\.(pdf|rtf|doc|docx|xls|xlsx|ppt|pptx|zip|rar|mp3|mp4|mpg|mpeg|avi|wmv|mov|apk|odt|ods|txt|csv)(\\?.*)?$")) {
                 Intent intent = new Intent(Intent.ACTION_VIEW);
                 intent.setDataAndType(Uri.parse(url), "*/*");

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -1194,7 +1194,7 @@ public class InAppBrowser extends CordovaPlugin {
 
             if (url.matches(".*\\.(pdf|rtf|doc|docx|xls|xlsx|ppt|pptx|zip|rar|mp3|mp4|mpg|mpeg|avi|wmv|mov|apk|odt|ods|txt|csv)(\\?.*)?$")) {
                 Intent intent = new Intent(Intent.ACTION_VIEW);
-                intent.setDataAndType(Uri.parse(url));
+                intent.setData(Uri.parse(url));
                 cordova.getActivity().startActivity(intent);
                 return true;
             }

--- a/src/android/InAppBrowserDialog.java
+++ b/src/android/InAppBrowserDialog.java
@@ -47,6 +47,13 @@ public class InAppBrowserDialog extends Dialog {
         } else {
             // better to go through the in inAppBrowser
             // because it does a clean up
+            // hardware_back config drives three behaviours:
+            //   disabled -> ignore the press entirely (prevents accidental exit)
+            //   yes      -> navigate back in history, close when there is none
+            //   no       -> close immediately (same as "yes" without history)
+            if (this.inAppBrowser.hardwareBackDisabled()) {
+                return;
+            }
             if (this.inAppBrowser.hardwareBack() && this.inAppBrowser.canGoBack()) {
                 this.inAppBrowser.goBack();
             }  else {


### PR DESCRIPTION
### Platforms affected

Android only


### Motivation and Context

Downloading files is blocked by the InAppBrowser by default. This PR opens up the possibility.

### Description

This adds some callback code which opens an ACTION_VIEW intent with a file when the file name extension matches a list of popular extensions.


### Testing

Point an InAppBrowser to a PDF URL. Without this patch, the browser does nothing. With this patch, a requester opens to choose the app to open the file with.


### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
