### PR TITLE
(android) Add three-state hardware_back configuration

### DIFF
--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -129,6 +129,7 @@ public class InAppBrowser extends CordovaPlugin {
     private boolean clearAllCache = false;
     private boolean clearSessionCache = false;
     private boolean hadwareBackButton = true;
+    private boolean hardwareBackDisabled = false;
     private boolean mediaPlaybackRequiresUserGesture = false;
     private boolean shouldPauseInAppBrowser = false;
     private boolean useWideViewPort = true;
@@ -580,6 +581,14 @@ public class InAppBrowser extends CordovaPlugin {
     }
 
     /**
+     * Has the user set the hardware back button to be ignored entirely
+     * @return boolean
+     */
+    public boolean hardwareBackDisabled() {
+        return hardwareBackDisabled;
+    }
+
+    /**
      * Checks to see if it is possible to go forward one page in history, then does so.
      */
     private void goForward() {
@@ -654,8 +663,10 @@ public class InAppBrowser extends CordovaPlugin {
             String hardwareBack = features.get(HARDWARE_BACK_BUTTON);
             if (hardwareBack != null) {
                 hadwareBackButton = hardwareBack.equals("yes") ? true : false;
+                hardwareBackDisabled = hardwareBack.equals("disabled") ? true : false;
             } else {
                 hadwareBackButton = DEFAULT_HARDWARE_BACK;
+                hardwareBackDisabled = false;
             }
             String mediaPlayback = features.get(MEDIA_PLAYBACK_REQUIRES_USER_ACTION);
             if (mediaPlayback != null) {

--- a/src/android/InAppBrowserDialog.java
+++ b/src/android/InAppBrowserDialog.java
@@ -47,6 +47,13 @@ public class InAppBrowserDialog extends Dialog {
         } else {
             // better to go through the in inAppBrowser
             // because it does a clean up
+            // hardware_back config drives three behaviours:
+            //   disabled -> ignore the press entirely (prevents accidental exit)
+            //   yes      -> navigate back in history, close when there is none
+            //   no       -> close immediately (same as "yes" without history)
+            if (this.inAppBrowser.hardwareBackDisabled()) {
+                return;
+            }
             if (this.inAppBrowser.hardwareBack() && this.inAppBrowser.canGoBack()) {
                 this.inAppBrowser.goBack();
             }  else {


### PR DESCRIPTION
### Platforms affected

Android only

### Motivation and Context

The current configuration options for hardware back button either use it for navigation or directly closing the browser. Some use-cases require that the button just doesn't do anything

### Description

Adds an additional "option" for the "hardware_back" configuration "disabled" additional to the exisiting "on" or "off". This disables the hardware back button completely to not do anything. In this case the surrounding app may need to provide an javascript API to close the InAppBrowser from within.

### Testing

Opening the browser with any of the three options for hardware_back yields to the expected behaviour:

"on" → The hardware back button can be used for "navigating" through the history of the browser
"off" → The hardware back button always closes the browser directly without using the browser history
"disabled"  → The hardware back button has no effect on the behaviour of the app

